### PR TITLE
Substitute ' ' for "

### DIFF
--- a/src/pymust/dasmtx.py
+++ b/src/pymust/dasmtx.py
@@ -234,7 +234,7 @@ def dasmtx(SIG : np.ndarray, x: np.ndarray, z: np.ndarray, *varargin):
 
     #%-- Interpolation method
     if method.lower() not in ['nearest','linear','quadratic','lanczos3','5points','lanczos5']:
-        raise ValueError('METHOD must be ''nearest'', ''linear'', ''quadratic'', ''Lanczos3'', ''5points'' or ''Lanczos5''.')
+        raise ValueError('METHOD must be "nearest", "linear", "quadratic", "Lanczos3", "5points" or "Lanczos5".')
 
 
     #%-- Propagation velocity (in m/s)

--- a/src/pymust/pfield.py
+++ b/src/pymust/pfield.py
@@ -322,10 +322,10 @@ def pfield(x : np.ndarray,y : np.ndarray, z: np.ndarray, delaysTX : np.ndarray, 
     elif param.baffle == 'soft':
         NonRigidBaffle = True
     elif np.isscalar(param.baffle):
-        assert param.baffle>0, 'The ''baffle'' field scalar must be positive'
+        assert param.baffle>0, 'The "baffle" field scalar must be positive'
         NonRigidBaffle = True
     else:
-        raise ValueError('The ''baffle'' field must be ''rigid'',''soft'' or a positive scalar')
+        raise ValueError('The "baffle" field must be "rigid","soft" or a positive scalar')
 
     #%-- 9) Longitudinal velocity (in m/s)
     if  'c' not in param:

--- a/src/pymust/smoothn.py
+++ b/src/pymust/smoothn.py
@@ -169,7 +169,7 @@ def smoothn(y : np.ndarray,
     #%---
     # "Weight function" criterion (for robust smoothing)
     Weight = Weight.lower()
-    assert Weight in ['bisquare','talworth','cauchy'], 'The weight function must be ''bisquare'', ''cauchy'' or '' talworth''.'
+    assert Weight in ['bisquare','talworth','cauchy'], 'The weight function must be "bisquare", "cauchy" or " talworth".'
     
     #---
     # "Order" criterion (by default m = 2)

--- a/src/pymust/txdelay.py
+++ b/src/pymust/txdelay.py
@@ -204,7 +204,7 @@ def txdelay(*args):
             delays = -delays
     #%-----
     elif option == 'Circular Wave':
-        assert isLINEAR,'The syntax ''TXDELAY(PARAM,TILT,WIDTH)is not available for a convex array.'
+        assert isLINEAR,'The syntax "TXDELAY(PARAM,TILT,WIDTH)" is not available for a convex array.'
         tilt = np.array(args[1]).reshape((-1, 1))
         width = np.array(args[2]).reshape((-1, 1))
         assert tilt.shape == width.shape, 'TILT and WIDTH must have the same length.'

--- a/src/pymust/wfilt.py
+++ b/src/pymust/wfilt.py
@@ -78,7 +78,7 @@ def wfilt(SIG :np.ndarray, method : str, n: int) -> np.ndarray :
         #% DISCRETE COSINE TRANSFORM WALL FILTER
         #% -------------------------------------
         
-        assert n>0, "N must be >0 with the ''dct'' method."
+        assert n>0, 'N must be >0 with the "dct" method.'
         assert N>=n,'The packet length must be >=N.'
         
         #% If the degree is 0, the mean is removed.
@@ -95,7 +95,7 @@ def wfilt(SIG :np.ndarray, method : str, n: int) -> np.ndarray :
         #% SINGULAR VALUE DECOMPOSITION WALL FILTER
         #% ----------------------------------------
         
-        assert n>0,'N must be >0 with the ''svd'' method.'
+        assert n>0,'N must be >0 with the "svd" method.'
         assert N>=n,'The packet length must be >=N.'
         
         #% Each column represents a column-rearranged frame.
@@ -105,6 +105,6 @@ def wfilt(SIG :np.ndarray, method : str, n: int) -> np.ndarray :
         SIG = U[:,n:N] @ S[n:N,n:N] @V[:,n:N].T; # high-pass filtering
         SIG = SIG.reshape(siz0)        
     else:
-        raise ValueError("METHOD must be ''poly'', ''dct'', or ''svd''.")
+        raise ValueError('METHOD must be "poly", "dct", or "svd".')
 
     return SIG


### PR DESCRIPTION
Double single quotes generated string concatenation instead of displaying quotes around the keywords.
Fixed by changing '' for " inside strings started by single quotes.