### PR TITLE
Include last index where GdB >options.dBThresh 

### DIFF
--- a/src/pymust/pfield.py
+++ b/src/pymust/pfield.py
@@ -563,7 +563,7 @@ def pfield(x : np.ndarray,y : np.ndarray, z: np.ndarray, delaysTX : np.ndarray, 
     GdB = 20*np.log10(1e-200 + S/np.max(S))# % gain in dB
     id = np.where(GdB >options.dBThresh)
     IDX = np.zeros(f.shape) != 0.
-    IDX[id[0][0]:id[0][-1]] = True
+    IDX[id[0][0]:id[0][-1]+1] = True
 
     f = f[IDX]
     nSampling = len(f)


### PR DESCRIPTION
When FREQUENCY SAMPLES are calculated and filtered, keeping only the significant components where(GdB >options.dBThresh), there is a discrepancy between MUST (MATLAB) implementation and PyMUST (Python) due discrepancies between including or excluding the stop number.
Fix: Make the stop number of the range (last index **+ 1**)

MUST implementation:
```matlab
%-- FREQUENCY SAMPLES
Nf = 2*ceil(param.fc/df)+1; % number of frequency samples
f = linspace(0,2*param.fc,Nf); % frequency samples
df = f(2); % update the frequency step
%- we keep the significant components only by using options.dBThresh
S = abs(pulseSpectrum(2*pi*f).*probeSpectrum(2*pi*f));
GdB = 20*log10(S/max(S)); % gain in dB
IDX = GdB>options.dBThresh;
IDX(find(IDX,1):find(IDX,1,'last')) = true;
f = f(IDX);
nSampling = length(f);
```

PyMUST proposed fix:
```python
#%-- FREQUENCY SAMPLES
Nf = int(2*np.ceil(param.fc/df)+1) # number of frequency samples
f = np.linspace(0,2*param.fc,Nf) # frequency samples
df = f[1]  #% update the frequency step
#%- we keep the significant components only by using options.dBThresh
S = np.abs(pulseSpectrum(2*np.pi*f)*probeSpectrum(2*np.pi*f))

GdB = 20*np.log10(1e-200 + S/np.max(S))# % gain in dB
id = np.where(GdB >options.dBThresh)
IDX = np.zeros(f.shape) != 0.
IDX[id[0][0]:id[0][-1]+1] = True

f = f[IDX]
nSampling = len(f)
```