### PR TITLE
Update comments on small d2 values replacement

### DIFF
--- a/src/pymust/pfield.py
+++ b/src/pymust/pfield.py
@@ -508,7 +508,8 @@ def pfield(x : np.ndarray,y : np.ndarray, z: np.ndarray, delaysTX : np.ndarray, 
     r = np.sqrt(d2+y.reshape((-1,1,1))**2).astype(np.float32)
     #%---
     #% we'll have 1/sqrt(r) or 1/r:
-    #% small d2 values are replaced by (lambda/4)^2
+    #% small d2 values are replaced by lambda/2
+    #% lambda = c/fc; smallD = lambda/2;
     smallD = (c/fc/2)
     r[r<smallD] = smallD
 


### PR DESCRIPTION
Corrected the comments to accurately reflect that small d2 values were replaced by lambda/2 = smallD, instead of (lambda/4)^2. Updated the commentary to lambda/2 and added the relation between smallD and lambda.