### PR TITLE
Remove Frequency correction

### DIFF
--- a/src/pymust/getpulse.py
+++ b/src/pymust/getpulse.py
@@ -116,10 +116,10 @@ def getpulse(param: utils.Param, way :int = 2, PreVel : str = 'pressure', dt : f
     elif PreVel.lower() in ['vel3d','velocity3d']:
             F = F / (f + eps)
 
-    # Corrected frequencies
-    P = np.abs(F)**2
-    Fc = np.trapz(f*P) / np.trapz(P)
-    f = f + Fc - fc
+    # Corrected frequencies % (added on April 24, 2023 ; removed on Nov 8, 2023) on MUST
+    # P = np.abs(F)**2
+    # Fc = np.trapz(f*P) / np.trapz(P)
+    # f = f + Fc - fc
 
     F = np.multiply(pulseSpectrum(2 * np.pi * f),probeSpectrum(2 * np.pi * f) ** way)
     

--- a/src/pymust/pfield.py
+++ b/src/pymust/pfield.py
@@ -569,16 +569,16 @@ def pfield(x : np.ndarray,y : np.ndarray, z: np.ndarray, delaysTX : np.ndarray, 
     nSampling = len(f)
 
 
-    #-- Frequency correction (added on April 24, 2023)
+    #-- Frequency correction (added on April 24, 2023; removed on Nov 8, 2023) on MUST
     #   Note: The frequencies are shifted such that the center frequency for a
     #         a pulse-echo is exactly PARAM.fc.
     # pulse-echo spectrum
-    F = pulseSpectrum(2*np.pi*f)*probeSpectrum(2*np.pi*f)**2;
+    # F = pulseSpectrum(2*np.pi*f)*probeSpectrum(2*np.pi*f)**2
     # predicted center frequency
-    P = np.abs(F)**2; #% power
-    Fc = np.trapz(f*P)/np.trapz(P)
+    # P = np.abs(F)**2; #% power
+    # Fc = np.trapz(f*P)/np.trapz(P)
     # corrected frequencies
-    #f = f+Fc-fc
+    # f = f+Fc-fc
 
     #%-- For MKMOVIE only: IDX is required in MKMOVIE
     if isMKMOVIE and x is None:


### PR DESCRIPTION
On MUST, the frequency correction was removed on November 8, 2023. This was partially reflected in PyMUST:

- The frequency change was removed from pfield.py, but some calculations of extra parameters were not removed, causing unnecessary runtime.
- In getpulse.py, the frequency change was not removed, affecting the results.

Fixed by commenting all the code related to Frequency correction to match MUST implementation.