### PR TITLE
Fixed and added annotations

### DIFF
--- a/src/pymust/bmode.py
+++ b/src/pymust/bmode.py
@@ -1,6 +1,6 @@
 import numpy as np
 from . import utils
-def bmode(IQ : np.ndarray, DR: float= 40) -> np.ndarray:
+def bmode(IQ: np.ndarray, DR: float = 40) -> np.ndarray:
 
     """
     %BMODE   B-mode image from I/Q signals

--- a/src/pymust/dasmtx.py
+++ b/src/pymust/dasmtx.py
@@ -5,7 +5,7 @@ import scipy, scipy.interpolate
 from . import  utils
 
 
-def dasmtx(SIG : np.ndarray, x: np.ndarray, z: np.ndarray, *varargin) -> scipy.sparse.spmatrix:
+def dasmtx(SIG: np.ndarray, x: np.ndarray, z: np.ndarray, *varargin) -> scipy.sparse.spmatrix:
     """
     %DASMTX   Delay-and-sum matrix
     %   M = DASMTX(SIG,X,Z,DELAYS,PARAM) returns the numel(X)-by-numel(SIG)

--- a/src/pymust/dasmtx3.py
+++ b/src/pymust/dasmtx3.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy, scipy.interpolate
 from . import  utils
 
-def dasmtx3(SIG : np.ndarray, x: np.ndarray, y: np.ndarray, z: np.ndarray, *varargin) -> scipy.sparse.spmatrix:
+def dasmtx3(SIG: np.ndarray, x: np.ndarray, y: np.ndarray, z: np.ndarray, *varargin) -> scipy.sparse.spmatrix:
     """
     DASMTX3   Delay-and-sum matrix for 3-D imaging with a matrix array
     M = DASMTX3(SIG,X,Y,Z,DELAYS,PARAM) returns the numel(X)-by-numel(SIG)

--- a/src/pymust/genscat.py
+++ b/src/pymust/genscat.py
@@ -4,7 +4,7 @@ from typing import Union
 from . import utils
 import numpy as np
 
-def genscat(roidim : np.ndarray, meandist: np.ndarray ,I : Union[np.ndarray, None]  = None, g: Union[np.ndarray, float] = None)  -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def genscat(roidim: np.ndarray, meandist: np.ndarray ,I: Union[np.ndarray, None]  = None, g: Union[np.ndarray, float] = None)  -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     %GENSCAT   Generate a distribution of scatterers
     %   [XS,YS,ZS] = GENSCAT([WIDTH HEIGHT],MEANDIST) generates a 2-D

--- a/src/pymust/getparam.py
+++ b/src/pymust/getparam.py
@@ -2,30 +2,30 @@ import numpy as np
 from . import utils
 
 
-def getparam(probe : str) -> utils.Param: 
+def getparam(probe: str) -> utils.Param:
     #GETPARAM   Get parameters of a uniform linear or convex array
 #   PARAM = GETPARAM opens a dialog box which allows you to select a
 #   transducer whose parameters are returned in PARAM.
-    
+
     #   PARAM = GETPARAM(PROBE), where PROBE is a string, returns the prameters
 #   of the transducer given by PROBE.
-    
+
     #   The structure PARAM is used in several functions of MUST (Matlab
 #   UltraSound Toolbox). The structure returned by GETPARAM contains only
 #   the fields that describe a transducer. Other fields may be required in
 #   some MUST functions.
-    
+
     #   PROBE can be one of the following:
 #   ---------------------------------
 #     1) 'L11-5v' (128-element, 7.6-MHz linear array)
 #     2) 'L12-3v' (192-element, 7.5-MHz linear array)
 #     3) 'C5-2v' (128-element, 3.6-MHz convex array)
 #     4) 'P4-2v' (64-element, 2.7-MHz phased array)
-    
+
     #   These are the <a
 #   href="matlab:web('https://verasonics.com/verasonics-transducers/')">Verasonics' transducers</a>.
 #   Feel free to complete this list for your own use.
-    
+
     #   PARAM is a structure that contains the following fields:
 #   --------------------------------------------------------
 #   1) PARAM.Nelements: number of elements in the transducer array
@@ -37,8 +37,8 @@ def getparam(probe : str) -> utils.Param:
 #   7) PARAM.radius: radius of curvature (in m, Inf for a linear array)
 #   8) PARAM.focus: elevation focus (in m)
 #   9) PARAM.height: element height (in m)
-    
-    
+
+
     #   Example:
 #   -------
 #   #-- Generate a focused pressure field with a phased-array transducer
@@ -62,21 +62,21 @@ def getparam(probe : str) -> utils.Param:
 #   c = colorbar;
 #   c.YTickLabel{end} = '0 dB';
 #   xlabel('[cm]')
-    
-    
+
+
     #   This function is part of <a
 #   href="matlab:web('https://www.biomecardio.com/MUST')">MUST</a> (Matlab UltraSound Toolbox).
 #   MUST (c) 2020 Damien Garcia, LGPL-3.0-or-later
-    
+
     #   See also TXDELAY, PFIELD, SIMUS, GETPULSE.
-    
+
     #   -- Damien Garcia -- 2015/03, last update: 2020/07
 #   website: <a
 #   href="matlab:web('https://www.biomecardio.com')">www.BiomeCardio.com</a>
     param = utils.Param()
     probe = probe.upper()
-  
-    
+
+
     # from computeTrans.m (Verasonics, version post Aug 2019)
     if 'L11-5V' == probe:
         # --- L11-5v (Verasonics) ---

--- a/src/pymust/getpulse.py
+++ b/src/pymust/getpulse.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import numpy as np
-from . import utils    
+from . import utils
 
-def getpulse(param: utils.Param, way :int = 2, PreVel : str = 'pressure', dt : float = 1e-09) -> tuple[np.ndarray, np.ndarray]: 
+def getpulse(param: utils.Param, way: int = 2, PreVel: str = 'pressure', dt: float = 1e-09) -> tuple[np.ndarray, np.ndarray]:
     #GETPULSE   Get the transmit pulse
 #   PULSE = GETPULSE(PARAM,WAY) returns the one-way or two-way transmit
 #   pulse with a time sampling of 1 nanosecond. Use WAY = 1 to get the

--- a/src/pymust/impolgrid.py
+++ b/src/pymust/impolgrid.py
@@ -1,6 +1,6 @@
 import numpy as np, logging, typing
 from . import utils
-def impolgrid(siz : typing.Union[int, np.ndarray, list ], zmax : float, width:float, param : utils.Param =None):
+def impolgrid(siz: typing.Union[int, np.ndarray, list], zmax: float, width: float, param: utils.Param = None):
     """
     %IMPOLGRID   Polar-type grid for ultrasound images
     %   IMPOLGRID returns a polar-type (fan-type) grid expressed in Cartesian
@@ -111,7 +111,7 @@ def impolgrid(siz : typing.Union[int, np.ndarray, list ], zmax : float, width:fl
     isLINEAR = np.isinf(R)
 
     if not isLINEAR and not noWidth:
-            logging.warning('MUST:impolgrid', 'The parameter WIDTH is ignored with a convex array.')
+        logging.warning('MUST:impolgrid', 'The parameter WIDTH is ignored with a convex array.')
 
     #%-- Origo (x0,z0)
     #% x0 = 0;

--- a/src/pymust/iq2doppler.py
+++ b/src/pymust/iq2doppler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import numpy as np,scipy, scipy.signal, typing
 from . import utils
-def iq2doppler(IQ:np.ndarray, param: utils.Param, M: typing.Union[int,np.ndarray ]= 1,lag :int=1) -> tuple[np.ndarray, np.ndarray]:
+def iq2doppler(IQ: np.ndarray, param: utils.Param, M: typing.Union[int,np.ndarray] = 1, lag: int = 1) -> tuple[np.ndarray, np.ndarray]:
     """
     %IQ2DOPPLER   Convert I/Q data to color Doppler
     %   VD = IQ2DOPPLER(IQ,PARAM) returns the Doppler velocities from the I/Q

--- a/src/pymust/pfield.py
+++ b/src/pymust/pfield.py
@@ -29,7 +29,7 @@ mysinc = lambda x = None: np.sin(np.abs(x) + eps)/ (np.abs(x) + eps) # [note: In
 #GB TODO: add wait bar
 #GB TODO: allow parallelization
 
-def pfield(x : np.ndarray,y : np.ndarray, z: np.ndarray, delaysTX : np.ndarray, param: utils.Param, isQuick : bool = False, options : utils.Options = None):
+def pfield(x: np.ndarray, y: np.ndarray, z: np.ndarray, delaysTX: np.ndarray, param: utils.Param, isQuick: bool = False, options: utils.Options = None):
 #PFIELD   RMS acoustic pressure field of a linear or convex array
 #   RP = PFIELD(X,Y,Z,DELAYS,PARAM) returns the radiation pattern of a
 #   uniform LINEAR or CONVEX array whose elements are excited at different

--- a/src/pymust/pfield3.py
+++ b/src/pymust/pfield3.py
@@ -25,7 +25,7 @@ def average_over_last_axis(X):
 eps = np.finfo(np.float32).eps
 mysinc = lambda x = None: np.sin(np.abs(x) + eps)/ (np.abs(x) + eps) # [note: In MATLAB/numpy, sinc is sin(pi*x)/(pi*x)]
  
-def pfield3(x : np.ndarray, y : np.ndarray, z: np.ndarray, delaysTX : np.ndarray, param: utils.Param, isQuick : bool = False, options : utils.Options = None):
+def pfield3(x: np.ndarray, y: np.ndarray, z: np.ndarray, delaysTX: np.ndarray, param: utils.Param, isQuick: bool = False, options: utils.Options = None):
     """
     PFIELD3   3-D RMS acoustic pressure field of a planar 2-D array
     RP = PFIELD3(X,Y,Z,DELAYS,PARAM) returns the three-dimensional

--- a/src/pymust/rf2iq.py
+++ b/src/pymust/rf2iq.py
@@ -2,7 +2,7 @@ import numpy as np, scipy, scipy.signal, logging
 from . import utils
 from typing import Union
 
-def rf2iq(RF : np.ndarray, Fs : Union[float, utils.Param], Fc : float = None, B : float = None) -> np.ndarray:
+def rf2iq(RF: np.ndarray, Fs: Union[float, utils.Param], Fc: float = None, B: float = None) -> np.ndarray:
     """
     %RF2IQ   I/Q demodulation of RF data
     %   IQ = RF2IQ(RF,Fs,Fc) demodulates the radiofrequency (RF) bandpass

--- a/src/pymust/simus.py
+++ b/src/pymust/simus.py
@@ -3,7 +3,7 @@ import logging, copy, multiprocessing, functools
 import numpy as np 
 
 # pfield wrapper so it is compatible with multiprocessing. Needs to be defined in a global scope
-def pfieldParallel(x, y, z, RC, delaysTX, param, options):
+def pfieldParallel(x: np.ndarray, y: np.ndarray, z: np.ndarray, RC: np.ndarray, delaysTX: np.ndarray, param: utils.Param, options: utils.Options):
     options = options.copy()
     options.ParPool = False # No parallel within the parallel
     options.RC = RC

--- a/src/pymust/simus3.py
+++ b/src/pymust/simus3.py
@@ -3,7 +3,7 @@ import logging, copy, multiprocessing, functools
 import numpy as np 
 
 # pfield wrapper so it is compatible with multiprocessing. Needs to be defined in a global scope
-def pfieldParallel3(x, y, z, RC, delaysTX, param, options):
+def pfieldParallel3(x: np.ndarray, y: np.ndarray, z: np.ndarray, RC: np.ndarray, delaysTX: np.ndarray, param: utils.Param, options: utils.Options):
     options = options.copy()
     options.ParPool = False # No parallel within the parallel
     options.RC = RC

--- a/src/pymust/smoothn.py
+++ b/src/pymust/smoothn.py
@@ -3,17 +3,17 @@ import scipy, numpy as np, typing, logging
 from . import utils
 
 
-def smoothn(y : np.ndarray,
-            W : typing.Optional[np.ndarray] = None, 
-            S  : typing.Optional[float] = None,  
-            axis : typing.Optional[np.ndarray] = None, # Use this to specify the axis indicating multicomponent data
-            TolZ : typing.Optional[float] = 1e-3,
-            MaxIter : typing.Optional[int] = 100,
-            Initial : typing.Optional[np.ndarray] = None,
-            Spacing : typing.Optional[np.ndarray] = None,
-            Order : typing.Optional[int] = 2,   
-            Weight : str = 'bisquare',
-            isrobust : bool = False ) -> tuple[np.ndarray, float, bool]:
+def smoothn(y: np.ndarray,
+            W: typing.Optional[np.ndarray] = None,
+            S: typing.Optional[float] = None,
+            axis: typing.Optional[np.ndarray] = None, # Use this to specify the axis indicating multicomponent data
+            TolZ: typing.Optional[float] = 1e-3,
+            MaxIter: typing.Optional[int] = 100,
+            Initial: typing.Optional[np.ndarray] = None,
+            Spacing: typing.Optional[np.ndarray] = None,
+            Order: typing.Optional[int] = 2,
+            Weight: str = 'bisquare',
+            isrobust: bool = False ) -> tuple[np.ndarray, float, bool]:
     """
     %SMOOTHN Robust spline smoothing for 1-D to N-D data.
     %   SMOOTHN provides a fast, automatized and robust discretized spline

--- a/src/pymust/sptrack.py
+++ b/src/pymust/sptrack.py
@@ -4,7 +4,7 @@ from . import utils, smoothn
 import numpy as np, scipy
 
 
-def sptrack(I : np.ndarray, param : utils.Param) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def sptrack(I: np.ndarray, param: utils.Param) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     %SPTRACK   Speckle tracking using Fourier-based cross-correlation
     %   [Di,Dj] = SPTRACK(I,PARAM) returns the motion field [Di,Dj] that occurs

--- a/src/pymust/sptrack_old.py
+++ b/src/pymust/sptrack_old.py
@@ -3,7 +3,7 @@ from . import utils, smoothn
 import numpy as np, scipy
 
 
-def sptrack(I : np.ndarray, param : utils.Param) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def sptrack(I: np.ndarray, param: utils.Param) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     %SPTRACK   Speckle tracking using Fourier-based cross-correlation
     %   [Di,Dj] = SPTRACK(I,PARAM) returns the motion field [Di,Dj] that occurs

--- a/src/pymust/txdelay.py
+++ b/src/pymust/txdelay.py
@@ -1,13 +1,13 @@
 from . import utils
 import numpy as np
 
-def txdelayCircular(param : utils.Param, tilt : float, width: float) -> np.ndarray:
+def txdelayCircular(param: utils.Param, tilt: float, width: float) -> np.ndarray:
     return txdelay(param, tilt, width)
 
-def txdelayPlane(param : utils.Param, tilt : float) -> np.ndarray:
+def txdelayPlane(param: utils.Param, tilt: float) -> np.ndarray:
     return txdelay(param, tilt)
 
-def txdelayFocused(param : utils.Param, x : float, y : float) -> np.ndarray:
+def txdelayFocused(param: utils.Param, x: float, y: float) -> np.ndarray:
     return txdelay(x, y, param)
 
 def txdelay(*args):

--- a/src/pymust/txdelay3.py
+++ b/src/pymust/txdelay3.py
@@ -2,13 +2,13 @@ from . import utils
 import numpy as np
 import scipy.optimize
 
-def txdelay3Plane(param, tiltx, tilty):
+def txdelay3Plane(param: utils.Param, tiltx: float, tilty: float) -> np.ndarray:
     return txdelay3(param, tiltx, tilty)
 
-def txdelay3Diverging(param, tiltx, tilty, omega):
+def txdelay3Diverging(param: utils.Param, tiltx: float, tilty: float, omega: float) -> np.ndarray:
     return txdelay3(param, tiltx, tilty, omega)
 
-def txdelay3Focused(param, x, y, z):
+def txdelay3Focused(param: utils.Param, x: float|np.ndarray, y: float|np.ndarray, z: float|np.ndarray) -> np.ndarray:
     return txdelay3(x, y, z, param)
 
 def txdelay3(*args):

--- a/src/pymust/wfilt.py
+++ b/src/pymust/wfilt.py
@@ -1,7 +1,7 @@
 import numpy as np,scipy, logging
 import typing
 
-def wfilt(SIG: np.ndarray, method: str, n: int) -> np.ndarray :
+def wfilt(SIG: np.ndarray, method: str, n: int) -> np.ndarray:
     """
     %WFILT   Wall filtering (or clutter filtering)
     %   fSIG = WFILT(SIG,METHOD,N) high-pass (wall) filters the RF or I/Q

--- a/src/pymust/wfilt.py
+++ b/src/pymust/wfilt.py
@@ -1,7 +1,7 @@
 import numpy as np,scipy, logging
 import typing
 
-def wfilt(SIG :np.ndarray, method : str, n: int) -> np.ndarray :
+def wfilt(SIG: np.ndarray, method: str, n: int) -> np.ndarray :
     """
     %WFILT   Wall filtering (or clutter filtering)
     %   fSIG = WFILT(SIG,METHOD,N) high-pass (wall) filters the RF or I/Q


### PR DESCRIPTION
Removed (some) trailing whitespaces and spaces between variables and semicolons to follow PEP8 formatting guidelines and ensure consistency with other annotations in the code.
The [PEP484](https://peps.python.org/pep-0484/#type-definition-syntax) and [PEP3107](https://peps.python.org/pep-3107/#syntax) guidelines and examples indicate that the correct spacing should be:
```python
def foo(a: expression, b: expression = 5):
    ...
```

TODO/CHECK:
- Consider in which modules annotations from __future__ should be imported.
- For functions with varying outputs, consider annotating the result (might not be insightful).