### PR TITLE
Add/Restore pfield call on first example

### DIFF
--- a/examples/pfield.ipynb
+++ b/examples/pfield.ipynb
@@ -248,6 +248,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "P, _, _  = pymust.pfield(x,y, z,txdel,param)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
On the last update of the file [Adapted virtual sources to dasmtx 2d](https://github.com/creatis-ULTIM/PyMUST/commit/f9edaddcf1f08795d4718924e357641844a7e664) the following line of code went missing (making the example notebook fail):

```python
P, _, _  = pymust.pfield(x,y, z,txdel,param)
```

> NOTE: on last pull request (#44), git didn't recognize the addition of the lines breaking the git history, now fixed