### PR TITLE
fix: escape backslash in \mus strings to resolve SyntaxWarning

### DIFF
--- a/examples/DW_echo_demo.ipynb
+++ b/examples/DW_echo_demo.ipynb
@@ -148,7 +148,7 @@
     "plt.figure(figsize = (5,5))\n",
     "plt.stem(txdel[0][0]*1e6)\n",
     "plt.xlabel('Element number')\n",
-    "plt.ylabel('Delays (\\mus)')\n",
+    "plt.ylabel(r'Delays (\\mus)')\n",
     "plt.title('TX delays for a 6$\\circ$-wide -20$\\circ$-tilted wave')\n"
    ]
   },

--- a/examples/multiline_transmit_demo.ipynb
+++ b/examples/multiline_transmit_demo.ipynb
@@ -220,7 +220,7 @@
    "source": [
     "plt.bar(np.arange(txdel.shape[1]), txdel[0]*1e6)\n",
     "plt.xlabel('Element number')\n",
-    "plt.ylabel('Delays (\\mus)')\n",
+    "plt.ylabel(r'Delays (\\mus)')\n",
     "plt.title('TX delays for a field focused at $2.5$ cm')\n"
    ]
   },
@@ -395,7 +395,7 @@
    "source": [
     "plt.bar(np.arange(txdel.shape[1]), txdel[0]*1e6)\n",
     "plt.xlabel('Element number')\n",
-    "plt.ylabel('Delays (\\mus)')\n",
+    "plt.ylabel(r'Delays (\\mus)')\n",
     "plt.title('TX delays for a 60{$\\circ$}-wide +10{$\\circ$}-tilted wave')\n"
    ]
   },
@@ -450,7 +450,7 @@
    "source": [
     "plt.bar(np.arange(txdel.shape[1]), txdel[0]*1e6)\n",
     "plt.xlabel('Element number')\n",
-    "plt.ylabel('Delays (\\mus)')\n",
+    "plt.ylabel(r'Delays (\\mus)')\n",
     "\n",
     "plt.title('TX delays for a virtual source at {0.37,-1.57} cm')\n"
    ]
@@ -803,7 +803,7 @@
     "bottom = np.zeros_like(x)\n",
     "ax1.bar3d(x.flatten(), y.flatten(), bottom.flatten(), width, depth, txdel.flatten(), shade=True)\n",
     "plt.xlabel('Element number')\n",
-    "ax1.set_zlabel('Delays (\\mus)')\n",
+    "ax1.set_zlabel(r'Delays (\\mus)')\n",
     "plt.title('TX delays for a 3-MLT transmit')\n",
     "ax1.zaxis.labelpad=.001\n",
     "plt.tight_layout()\n",

--- a/examples/quickstart_demo.ipynb
+++ b/examples/quickstart_demo.ipynb
@@ -317,7 +317,7 @@
     "iq = IQ[0][:,63];\n",
     "plt.plot(t,np.real(iq), label = 'in-phase')\n",
     "plt.plot(t,np.imag(iq), label = 'quadrature')\n",
-    "plt.xlabel('time (\\mus)')\n",
+    "plt.xlabel(r'time (\\mus)')\n",
     "plt.title('I/Q signal of the 64^{th} element (1^{st} series, tilt = -10{\\circ})')\n",
     "plt.legend()\n"
    ]

--- a/examples/rotatingDiskVelocitySyntheticML.ipynb
+++ b/examples/rotatingDiskVelocitySyntheticML.ipynb
@@ -1269,7 +1269,7 @@
       "   199                                               %      (0:size(RF,1)-1)/param.fs*1e6,'k')\n",
       "   200                                               %   set(gca,'XTick',1:10,'XTickLabel',int2str((1:7:64)'))\n",
       "   201                                               %   title('RF signals')\n",
-      "   202                                               %   xlabel('Element number'), ylabel('time (\\mus)')\n",
+      "   202                                               %   xlabel('Element number'), ylabel('time (\\\\mus)')\n",
       "   203                                               %   xlim([0 11]), axis ij \n",
       "   204                                               %   \n",
       "   205                                               %\n",

--- a/src/pymust/mkmovie.py
+++ b/src/pymust/mkmovie.py
@@ -157,7 +157,7 @@ def mkmovie(*varargin):
     %       scatter(x,z,5,'w','filled')
     %       hold off
     %       axis equal off
-    %       title([int2str(info.TimeStep*k*1e6) ' \mus'])
+    %       title([int2str(info.TimeStep*k*1e6) ' \\mus'])
     %       drawnow
     %   end
     %

--- a/src/pymust/simus.py
+++ b/src/pymust/simus.py
@@ -200,7 +200,7 @@ def simus(*varargin):
     %      (0:size(RF,1)-1)/param.fs*1e6,'k')
     %   set(gca,'XTick',1:10,'XTickLabel',int2str((1:7:64)'))
     %   title('RF signals')
-    %   xlabel('Element number'), ylabel('time (\mus)')
+    %   xlabel('Element number'), ylabel('time (\\mus)')
     %   xlim([0 11]), axis ij 
     %   
     %


### PR DESCRIPTION
## Summary

Fixes `SyntaxWarning: invalid escape sequence '\m'` emitted by Python 3.12+ in string literals containing `\mus` (intended as LaTeX mu-seconds).

Changes affect:
- **src/pymust/simus.py:203** - docstring MATLAB example code
- **src/pymust/mkmovie.py:160** - docstring MATLAB example code  
- **examples/*.ipynb** - matplotlib axis labels using raw strings

## Solution

- Docstrings: Escaped backslash as `\\mus` so the rendered docstring contains literal `\mus`
- Notebooks: Use raw strings `r'time (\mus)'` to preserve literal backslash without Python escape processing

## Testing

Verified import-time warnings are resolved:
```bash
$ uv run python -W error -c "import pymust"
# exit code 0 (no warnings treated as errors)

$ uv run python -c "import pymust" 2>&1  
# no output (no SyntaxWarning displayed)
```

Before fix:
```
SyntaxWarning: invalid escape sequence '\m'
  /path/to/site-packages/pymust/simus.py:203
  %   xlabel('Element number'), ylabel('time (\mus)')
```

After fix: No warnings.